### PR TITLE
Add print output for created files

### DIFF
--- a/Capsule_Dev_Shell_Kit.py
+++ b/Capsule_Dev_Shell_Kit.py
@@ -18,4 +18,4 @@ with zipfile.ZipFile(output_zip, "w", zipfile.ZIP_DEFLATED) as zipf:
         if os.path.exists(file_path):
             zipf.write(file_path, arcname=file)
 
-output_zip
+print(output_zip)

--- a/Generate.py
+++ b/Generate.py
@@ -131,4 +131,4 @@ MimeType=x-scheme-handler/capsule;
 with open(protocol_kit_path, "w") as f:
     f.write(protocol_kit)
 
-(index_html_path, sigil_artifact_path, protocol_kit_path)
+print((index_html_path, sigil_artifact_path, protocol_kit_path))

--- a/Inject_broadcast.py
+++ b/Inject_broadcast.py
@@ -55,4 +55,4 @@ with zipfile.ZipFile(camp_final, 'w', zipfile.ZIP_DEFLATED) as zipf:
             arcname = os.path.relpath(full_path, start=inject_dir)
             zipf.write(full_path, arcname=arcname)
 
-camp_final
+print(camp_final)

--- a/Light3_Reflex_Shrine_Healed.py
+++ b/Light3_Reflex_Shrine_Healed.py
@@ -67,4 +67,4 @@ with zipfile.ZipFile(final_camp, 'w', zipfile.ZIP_DEFLATED) as zipf:
             arcname = os.path.relpath(full_path, start=output_dir)
             zipf.write(full_path, arcname=arcname)
 
-final_camp
+print(final_camp)

--- a/Operator_Browser_Cortex_v3.py
+++ b/Operator_Browser_Cortex_v3.py
@@ -106,4 +106,4 @@ with ZipFile(camp_zip_path, "w") as zipf:
             arcname = os.path.relpath(full_path, start=camp_dir)
             zipf.write(full_path, arcname=arcname)
 
-camp_zip_path
+print(camp_zip_path)

--- a/Operator_MindCapsule.py
+++ b/Operator_MindCapsule.py
@@ -100,4 +100,4 @@ with zipfile.ZipFile(camp_path, 'w', zipfile.ZIP_DEFLATED) as camp_zip:
             arcname = os.path.relpath(file_path, capsule_dir)
             camp_zip.write(file_path, arcname=arcname)
 
-camp_path
+print(camp_path)

--- a/Operator_Reflex_Capsule_X.py
+++ b/Operator_Reflex_Capsule_X.py
@@ -111,4 +111,4 @@ with ZipFile(enhanced_capsule_path, "w") as zipf:
             arcname = os.path.relpath(full_path, start=capsule_dir)
             zipf.write(full_path, arcname=arcname)
 
-enhanced_capsule_path
+print(enhanced_capsule_path)

--- a/brpwsweragentzero.py
+++ b/brpwsweragentzero.py
@@ -83,4 +83,4 @@ with ZipFile(final_zip_path, "w") as zipf:
     for fname in os.listdir(final_dir):
         zipf.write(os.path.join(final_dir, fname), arcname=fname)
 
-final_zip_path
+print(final_zip_path)

--- a/full_shrine_deployment_token.py
+++ b/full_shrine_deployment_token.py
@@ -35,4 +35,4 @@ echo "✅ Capsule is now up to date."
 # Save QR
 qr_img.save(qr_path)
 
-(qr_path, desktop_stub_path, update_script_path)
+print((qr_path, desktop_stub_path, update_script_path))

--- a/importSeal.py
+++ b/importSeal.py
@@ -82,4 +82,4 @@ with open(blessing_log, "a") as log:
     log.write(f"[{timestamp}] Light3_Reflex_Shrine_Healed.camp sealed by Agent 0. SHA256: {digest}\n")
 
 # Return paths to sealed output
-(camp_output, sig_output, readme_output, qr_output, blessing_log)
+print((camp_output, sig_output, readme_output, qr_output, blessing_log))

--- a/inject.py
+++ b/inject.py
@@ -56,4 +56,4 @@ while True:
 with open(watch_path, "w") as f:
     f.write(watch_code)
 
-(broadcast_path, watch_path)
+print((broadcast_path, watch_path))

--- a/light.py
+++ b/light.py
@@ -100,7 +100,7 @@ with ZipFile(camp_zip_path, "w") as zipf:
             arcname = os.path.relpath(full_path, start=camp_dir)
             zipf.write(full_path, arcname=arcname)
 
-camp_zip_path
+print(camp_zip_path)
 
 
 

--- a/light2.py
+++ b/light2.py
@@ -101,4 +101,4 @@ with ZipFile(upgrade_zip_path, "w") as zipf:
     zipf.write(os.path.join(overlay_dir, "agent_console.html"), arcname="agent_console.html")
     zipf.write(os.path.join(overlay_dir, "reflex_overlay.js"), arcname="reflex_overlay.js")
 
-upgrade_zip_path
+print(upgrade_zip_path)

--- a/light3.py
+++ b/light3.py
@@ -56,4 +56,4 @@ socket_zip_path = "/mnt/data/Reflex_Socket_Fused.zip"
 with ZipFile(socket_zip_path, "w") as zipf:
     zipf.write(socket_path, arcname="reflex_socket.py")
 
-socket_zip_path
+print(socket_zip_path)

--- a/mesh_sidloadout.py
+++ b/mesh_sidloadout.py
@@ -37,4 +37,4 @@ with zipfile.ZipFile(zip_path, "w") as zipf:
         zipf.write(os.path.join(working_dir, filename), arcname=filename)
     zipf.write(qr_img_path, arcname="operator_mesh_qr.png")
 
-zip_path
+print(zip_path)

--- a/operator_mesh.py
+++ b/operator_mesh.py
@@ -37,4 +37,4 @@ with zipfile.ZipFile(zip_path, "w") as zipf:
         zipf.write(os.path.join(working_dir, filename), arcname=filename)
     zipf.write(qr_img_path, arcname="operator_mesh_qr.png")
 
-zip_path
+print(zip_path)

--- a/opex_out.py
+++ b/opex_out.py
@@ -37,4 +37,4 @@ with zipfile.ZipFile(zip_path, "w") as zipf:
         zipf.write(os.path.join(working_dir, filename), arcname=filename)
     zipf.write(qr_img_path, arcname="operator_mesh_qr.png")
 
-zip_path
+print(zip_path)

--- a/reflex_socket.py
+++ b/reflex_socket.py
@@ -125,4 +125,4 @@ with ZipFile(ritual_zip_path, "w") as zipf:
     zipf.write(os.path.join(ritual_dir, "trigger_rules.yaml"), arcname="trigger_rules.yaml")
     zipf.write(os.path.join(ritual_dir, "reflex_overlay.js"), arcname="reflex_overlay.js")
 
-ritual_zip_path
+print(ritual_zip_path)


### PR DESCRIPTION
## Summary
- print created archive paths at end of helper scripts

## Testing
- `python -m py_compile Capsule_Dev_Shell_Kit.py Generate.py Inject_broadcast.py Light3_Reflex_Shrine_Healed.py Operator_Browser_Cortex_v3.py Operator_MindCapsule.py Operator_Reflex_Capsule_X.py brpwsweragentzero.py full_shrine_deployment_token.py importSeal.py inject.py light.py light2.py light3.py mesh_sidloadout.py operator_mesh.py opex_out.py reflex_socket.py`

## Summary by Sourcery

Enhancements:
- Print output paths of created archives, QR codes, protocol kits, and other artifacts at the end of each helper script