### PR TITLE
Fix missing imports in importSeal

### DIFF
--- a/importSeal.py
+++ b/importSeal.py
@@ -1,6 +1,8 @@
 import hashlib
 import zipfile
 import qrcode
+import shutil
+import os
 from datetime import datetime
 
 # === Define paths ===


### PR DESCRIPTION
## Summary
- ensure `importSeal.py` imports `shutil` and `os`
- verify no other missing imports

## Testing
- `python -m py_compile importSeal.py`

## Summary by Sourcery

Bug Fixes:
- Add missing imports for shutil and os in importSeal.py