### PR TITLE
Add minimal dashboard server

### DIFF
--- a/dashboard_server.py
+++ b/dashboard_server.py
@@ -1,0 +1,22 @@
+from flask import Flask, send_from_directory
+import os
+
+app = Flask(__name__, static_folder=".", static_url_path="")
+
+@app.route('/')
+def index():
+    # Serve index.html if available
+    if os.path.exists('index.html'):
+        return app.send_static_file('index.html')
+    return '<h1>Capsule Dashboard</h1>'
+
+@app.route('/<path:filename>')
+def static_files(filename):
+    # Serve any other static file in the repository directory
+    if os.path.exists(filename):
+        return send_from_directory('.', filename)
+    return '', 404
+
+if __name__ == '__main__':
+    port = int(os.environ.get('DASHBOARD_PORT', 8686))
+    app.run(host='0.0.0.0', port=port)


### PR DESCRIPTION
## Summary
- implement a basic Flask dashboard server

## Testing
- `python -m py_compile dashboard_server.py`

## Summary by Sourcery

Add a minimal Flask-based dashboard server script with static file serving and configurable port

New Features:
- Introduce dashboard_server.py with Flask routes to serve index.html at `/` or fallback to default HTML
- Add a catch-all route to serve static files from the project directory
- Enable configurable server port via `DASHBOARD_PORT` environment variable (default 8686)