### PR TITLE
Add optional ace_tools support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ Key Python dependencies listed in `requirements.txt` include:
 - qrcode
 - pillow
 - python-dotenv
+- ace_tools (optional, provides a small UI for displaying DataFrames)
+
+`ace_tools` is used by the capsule auditor utilities to present audit results
+in a pop‑up window. If the package is missing, the scripts will simply print
+results to the console.

--- a/capsule_auditor.py
+++ b/capsule_auditor.py
@@ -210,8 +210,15 @@ if __name__ == "__main__":
     repaired, summary = scan_and_repair_capsules(dry_run=args.audit_only)
 
     if not args.audit_only:
-        import ace_tools as tools
-        tools.display_dataframe_to_user(name="Repaired Capsules", dataframe={"Repaired Capsules": repaired})
+        try:
+            import ace_tools as tools
+        except ImportError:
+            tools = None
+
+        if tools is not None:
+            tools.display_dataframe_to_user(name="Repaired Capsules", dataframe={"Repaired Capsules": repaired})
+        else:
+            print("ace_tools not installed; skipping DataFrame display")
 
         with open(os.path.join(AUDITOR_OUTPUT_DIR, "audit_summary_all.json"), "w") as f:
             json.dump(summary, f, indent=2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pillow
 python-dotenv
 eventlet
 qrcode
+ace_tools

--- a/validate_manifest.py
+++ b/validate_manifest.py
@@ -210,8 +210,15 @@ if __name__ == "__main__":
     repaired, summary = scan_and_repair_capsules(dry_run=args.audit_only)
 
     if not args.audit_only:
-        import ace_tools as tools
-        tools.display_dataframe_to_user(name="Repaired Capsules", dataframe={"Repaired Capsules": repaired})
+        try:
+            import ace_tools as tools
+        except ImportError:
+            tools = None
+
+        if tools is not None:
+            tools.display_dataframe_to_user(name="Repaired Capsules", dataframe={"Repaired Capsules": repaired})
+        else:
+            print("ace_tools not installed; skipping DataFrame display")
 
         with open(os.path.join(AUDITOR_OUTPUT_DIR, "audit_summary_all.json"), "w") as f:
             json.dump(summary, f, indent=2)


### PR DESCRIPTION
## Summary
- handle missing `ace_tools` gracefully in capsule scripts
- document `ace_tools` usage
- include `ace_tools` dependency in requirements

## Testing
- `python -m py_compile validate_manifest.py capsule_auditor.py`

## Summary by Sourcery

Make ace_tools integration optional in capsule auditing utilities and update project documentation and dependencies accordingly

Enhancements:
- Gracefully handle missing ace_tools in capsule auditor and manifest validation scripts by falling back to console output

Build:
- Add ace_tools to requirements.txt as an optional dependency

Documentation:
- Document optional ace_tools usage and behavior in README