### PR TITLE
Add operator repair node daemon

### DIFF
--- a/operator_repair_node.py
+++ b/operator_repair_node.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+import time
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+from capsule_auditor import scan_and_repair_capsules
+
+WATCH_DIR = "/mnt/data"
+BACKUP_DIR = "repair_backups"
+
+class CapsuleEventHandler(FileSystemEventHandler):
+    def on_created(self, event):
+        if event.is_directory:
+            return
+        if event.src_path.endswith((".zip", ".camp")):
+            os.makedirs(BACKUP_DIR, exist_ok=True)
+            dest = os.path.join(BACKUP_DIR, os.path.basename(event.src_path))
+            try:
+                shutil.copy2(event.src_path, dest)
+                print(f"Backed up {event.src_path} to {dest}")
+            except Exception as e:
+                print(f"Failed to back up {event.src_path}: {e}")
+            try:
+                scan_and_repair_capsules(base_dir=WATCH_DIR)
+            except Exception as e:
+                print(f"Error repairing capsules: {e}")
+
+
+def main():
+    observer = Observer()
+    event_handler = CapsuleEventHandler()
+    observer.schedule(event_handler, WATCH_DIR, recursive=False)
+    observer.start()
+    print(f"Watching {WATCH_DIR} for new capsules...")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pillow
 python-dotenv
 eventlet
 qrcode
+watchdog


### PR DESCRIPTION
## Summary
- add operator repair node daemon using watchdog
- backup capsule files and run auditor on change
- include watchdog in requirements

## Testing
- `python -m py_compile operator_repair_node.py`
- `python -m py_compile capsule_auditor.py`
- `pip install watchdog` *(fails: no network access)*

## Summary by Sourcery

Add an operator repair node daemon that watches for new capsule files, backs them up, and runs the capsule auditor on changes

New Features:
- Introduce operator_repair_node script using watchdog to monitor /mnt/data for new .zip or .camp files and trigger repair

Build:
- Add watchdog to project requirements