### PR TITLE
Add main function to operator_mesh

### DIFF
--- a/operator_mesh.py
+++ b/operator_mesh.py
@@ -1,40 +1,56 @@
 import zipfile
 import os
-import qrcode
 
-# Paths and filenames
-working_dir = "/mnt/data/operator_mesh_extension_output"
-os.makedirs(working_dir, exist_ok=True)
+try:
+    import qrcode  # optional dependency for real QR generation
+    _HAS_QRCODE = True
+except ImportError:  # pragma: no cover - fallback when qrcode is unavailable
+    _HAS_QRCODE = False
 
-# Core file list to include in the ZIP
-files_to_include = {
-    "browser_reflex.js": "Hook browser state into reflex_socket",
-    "camp_route.js": "Enable .camp drag-drop interpretation",
-    "agent_console.html": "Agent 0 control panel",
-    "manifest.json": "Patched with reflex domains and QR metadata"
-}
+def main() -> str:
+    """Build the Operator Mesh Extension Kit and return the zip path."""
 
-# Simulate content and create files (in real use, these would be actual contents)
-for filename, content in files_to_include.items():
-    with open(os.path.join(working_dir, filename), "w") as f:
-        f.write(f"// {content}\n")
+    # Paths and filenames
+    working_dir = "/mnt/data/operator_mesh_extension_output"
+    os.makedirs(working_dir, exist_ok=True)
 
-# Generate QR code data
-qr_data = {
-    "invoke": "Operator_Mesh_Extension_Kit",
-    "reflex": "browser_socket_bridge",
-    "camp": "enabled",
-    "entry": "agent_console.html",
-    "meta": "QR sideload ritual"
-}
-qr_img_path = os.path.join(working_dir, "operator_mesh_qr.png")
-qrcode.make(str(qr_data)).save(qr_img_path)
+    # Core file list to include in the ZIP
+    files_to_include = {
+        "browser_reflex.js": "Hook browser state into reflex_socket",
+        "camp_route.js": "Enable .camp drag-drop interpretation",
+        "agent_console.html": "Agent 0 control panel",
+        "manifest.json": "Patched with reflex domains and QR metadata",
+    }
 
-# Create a final zip with all components
-zip_path = "/mnt/data/Operator_Mesh_Extension_Kit_QR_Infused.zip"
-with zipfile.ZipFile(zip_path, "w") as zipf:
-    for filename in files_to_include.keys():
-        zipf.write(os.path.join(working_dir, filename), arcname=filename)
-    zipf.write(qr_img_path, arcname="operator_mesh_qr.png")
+    # Simulate content and create files (in real use, these would be actual contents)
+    for filename, content in files_to_include.items():
+        with open(os.path.join(working_dir, filename), "w") as f:
+            f.write(f"// {content}\n")
 
-print(zip_path)
+    # Generate QR code data
+    qr_data = {
+        "invoke": "Operator_Mesh_Extension_Kit",
+        "reflex": "browser_socket_bridge",
+        "camp": "enabled",
+        "entry": "agent_console.html",
+        "meta": "QR sideload ritual",
+    }
+    qr_img_path = os.path.join(working_dir, "operator_mesh_qr.png")
+    if _HAS_QRCODE:
+        qrcode.make(str(qr_data)).save(qr_img_path)
+    else:
+        with open(qr_img_path, "w") as f:
+            f.write(str(qr_data))
+
+    # Create a final zip with all components
+    zip_path = "/mnt/data/Operator_Mesh_Extension_Kit_QR_Infused.zip"
+    with zipfile.ZipFile(zip_path, "w") as zipf:
+        for filename in files_to_include.keys():
+            zipf.write(os.path.join(working_dir, filename), arcname=filename)
+        zipf.write(qr_img_path, arcname="operator_mesh_qr.png")
+
+    return zip_path
+
+
+if __name__ == "__main__":
+    print(main())


### PR DESCRIPTION
## Summary
- refactor `operator_mesh.py` into a `main()` function
- gracefully handle missing `qrcode` dependency
- add standard `if __name__ == '__main__':` entrypoint

## Testing
- `python operator_mesh.py`
- `unzip -l /mnt/data/Operator_Mesh_Extension_Kit_QR_Infused.zip`

## Summary by Sourcery

Refactor the Operator Mesh script into a reusable main() function, add graceful fallback when the optional qrcode dependency is missing, and introduce a standard CLI entrypoint

Enhancements:
- Encapsulate script logic inside a main() function that returns the ZIP path
- Implement optional qrcode import with a fallback that writes raw QR data if unavailable
- Add an if __name__ == "__main__" block to enable direct execution via python operator_mesh.py