### PR TITLE
Update auditor references

### DIFF
--- a/Capsule_Dev_Shell_Kit.py
+++ b/Capsule_Dev_Shell_Kit.py
@@ -3,7 +3,7 @@ import zipfile
 
 output_zip = "/mnt/data/Capsule_Dev_Shell_Kit.zip"
 files_to_include = [
-    "reflex_capsule_auditor.py",
+    "capsule_auditor.py",
     "requirements.txt",
     "launch_capsule.sh",
     "reflex_debug_mode.bat",

--- a/Capsule_Dev_Shell_Kit_SHRINE.camp
+++ b/Capsule_Dev_Shell_Kit_SHRINE.camp
@@ -17,8 +17,7 @@ with zipfile.ZipFile(camp_src, 'r') as zip_ref:
 with open(os.path.join(camp_dir, "__launch.sh"), "w") as f:
     f.write("""#!/bin/bash
 echo "⚙️ Booting Capsule Dev Shell Kit..."
-chmod +x reflex_capsule_auditor.py
-python3 reflex_capsule_auditor.py --audit-only
+python3 capsule_auditor.py --audit-only
 if [ -f dashboard_server.py ]; then
     python3 dashboard_server.py &
 fi
@@ -28,7 +27,7 @@ fi
 with open(os.path.join(camp_dir, "__launch.bat"), "w") as f:
     f.write("""@echo off
 echo Launching Capsule Dev Shell Kit...
-python reflex_capsule_auditor.py --audit-only
+python capsule_auditor.py --audit-only
 start dashboard_server.py
 """)
 

--- a/Inject_broadcast.py
+++ b/Inject_broadcast.py
@@ -45,7 +45,7 @@ import datetime
 log = "reflect.log"
 with open(log, "a") as f:
     f.write(f"[{{datetime.datetime.utcnow().isoformat()}}Z] Reflecting on capsule state...\\n")
-    result = subprocess.run(["python3", "reflex_capsule_auditor.py", "--audit-only"], capture_output=True, text=True)
+    result = subprocess.run(["python3", "capsule_auditor.py", "--audit-only"], capture_output=True, text=True)
     f.write(result.stdout + "\\n")
 """
 with open(os.path.join(inject_dir, "reflect_on_launch.py"), "w") as f:

--- a/Light3_Reflex_Shrine_Healed.py
+++ b/Light3_Reflex_Shrine_Healed.py
@@ -12,7 +12,7 @@ os.makedirs(capsules_dir, exist_ok=True)
 
 # Move core launch and audit tools to root of output bundle
 core_files = [
-    "reflex_capsule_auditor.py", "requirements.txt", "autorun.yaml",
+    "capsule_auditor.py", "requirements.txt", "autorun.yaml",
     "__launch.sh", "__launch.bat", "capsule_launcher.html", "reflex_debug_mode.bat",
     "Capsule_Shrine_OneClick_Launcher.html"
 ]

--- a/__launch.bat
+++ b/__launch.bat
@@ -1,4 +1,4 @@
 @echo off
 echo Launching Capsule Dev Shell Kit...
-python reflex_capsule_auditor.py --audit-only
+python capsule_auditor.py --audit-only
 start dashboard_server.py

--- a/__launch.sh
+++ b/__launch.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 echo "⚙️ Booting Capsule Dev Shell Kit..."
-chmod +x reflex_capsule_auditor.py
-python3 reflex_capsule_auditor.py --audit-only
+python3 capsule_auditor.py --audit-only
 if [ -f dashboard_server.py ]; then
     python3 dashboard_server.py &
 fi

--- a/launch_capsule.bat
+++ b/launch_capsule.bat
@@ -5,7 +5,7 @@ setlocal enabledelayedexpansion
 set CAPSULE_DIR=%cd%
 set PYTHON_EXE=python
 set REQUIREMENTS=requirements.txt
-set VALIDATOR=reflex_capsule_auditor.py
+set VALIDATOR=capsule_auditor.py
 set PORTABLE_GPT=http://localhost:11434/gpt
 
 echo.

--- a/launch_lin_wsl_capsule.sh
+++ b/launch_lin_wsl_capsule.sh
@@ -3,7 +3,7 @@ set -e
 
 CAPSULE_DIR="$(pwd)"
 REQUIREMENTS="requirements.txt"
-VALIDATOR="reflex_capsule_auditor.py"
+VALIDATOR="capsule_auditor.py"
 PORTABLE_GPT="http://localhost:11434/gpt"
 
 echo ""

--- a/reflex_debug_mode.bat
+++ b/reflex_debug_mode.bat
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 set CAPSULE_DIR=%cd%
 set PYTHON_EXE=python
 set REQUIREMENTS=requirements.txt
-set VALIDATOR=reflex_capsule_auditor.py
+set VALIDATOR=capsule_auditor.py
 
 echo 🐛 Reflex Debug Mode: Verbose Audit Starting...
 echo ==============================================


### PR DESCRIPTION
## Summary
- update scripts to use `capsule_auditor.py`
- remove obsolete `chmod` call
- ensure all references to `reflex_capsule_auditor.py` are dropped

## Testing
- `python -m py_compile Inject_broadcast.py Light3_Reflex_Shrine_Healed.py Capsule_Dev_Shell_Kit_SHRINE.camp Capsule_Dev_Shell_Kit.py`

## Summary by Sourcery

Replace deprecated Reflex auditor script references with the new Capsule auditor and remove obsolete chmod invocation

Chores:
- Update all scripts and Python code to call capsule_auditor.py instead of reflex_capsule_auditor.py
- Remove redundant chmod +x reflex_capsule_auditor.py step from launch script